### PR TITLE
add Insecure to RestoreOperationRequest

### DIFF
--- a/resources/client_gen/api_defs/instaclustr_icarus.yaml
+++ b/resources/client_gen/api_defs/instaclustr_icarus.yaml
@@ -639,6 +639,10 @@ components:
           description: |
             if set to true, host id of node to restore will be resolved from remote topology file located in a bucket by translating it from provided
             nodeId of storageLocation field
+        insecure:
+          type: boolean
+          description: |
+            Relevant during upload to S3-like bucket only. If true, communication is done via HTTP instead of HTTPS. Defaults to false.
         skipBucketVerification:
           type: boolean
           description: |


### PR DESCRIPTION
(and implicitly to RestoreOperationResponse)

I tried running `./regenerate.sh`, it worked fine with regenerating the Insecure part in the `model_restore_operation*.go` and `RestoreOperation*.md` files but I also got a lot of other changes in other files e.g. 
```
Progress float64 `json:"progress"`
```
to
```
Progress string `json:"progress"`
```

and new 
```
import (
	"time"
)
```

fixes https://github.com/instaclustr/instaclustr-icarus-go-client/issues/3